### PR TITLE
Feature: Add tables for Genre and musicAlbum classes in schema.sql

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -17,3 +17,25 @@ CREATE TABLE games(
     PRIMARY KEY(id),
     CONSTRAINT fk_authors FOREIGN KEY(games_id) REFERENCES authors(id)
 );
+
+-- Genre
+CREATE TABLE genre(
+    id INT GENERATED ALWAYS AS IDENTITY,
+    name VARCHAR(255) NOT NULL,
+    PRIMARY KEY(id)
+);
+
+-- MusicAlbum
+CREATE TABLE musicAlbum(
+    id INT GENERATED ALWAYS AS IDENTITY,
+    publish_date DATE NOT NULL,
+    archived BOOLEAN,
+    on_spotify BOOLEAN,
+    genre_id INT NOT NULL,
+    author_id INT NOT NULL,
+    label_id INT NOT NULL,
+    PRIMARY KEY(id),
+    FOREIGN KEY (genre_id) REFERENCES genre(id),
+    FOREIGN KEY (author_id) REFERENCES authors(id),
+    FOREIGN KEY (label_id) REFERENCES label(id),
+);


### PR DESCRIPTION
I was working on the tables for `Genre` and `MusicAlbums` and I achieve the following tasks:

- Create `Genre` table with properties. ✔️ 
- Create `musicAlbums` table with all properties and associations from the parent elements. ✔️ 