### PR TITLE
Feature: preserve data label and book

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -15,12 +15,12 @@ class App
   attr_accessor :music_albums, :genre, :authors, :games, :labels, :books
 
   def initialize
+    @labels = load_labels
     @genre = load_genres
     @authors = load_authors
     @music_albums = load_music_albums
     @games = load_games
-    @labels = []
-    @books = []
+    @books = load_books
   end
 
   def run

--- a/app.rb
+++ b/app.rb
@@ -47,22 +47,22 @@ class App
       Author.list_all_authors(authors)
     when 7
       Book.add_books(books, genre, authors, labels)
-      # write_books
-      # write_genres
-      # write_authors
-      # write_labels
+      write_books
+      write_genres
+      write_authors
+      write_labels
     when 8
       MusicAlbum.add_music_album(music_albums, genre, authors, labels)
       write_genres
       write_music_albums
       write_authors
-      # write_labels
+      write_labels
     when 9
       Game.add_games(games, genre, authors, labels)
       write_games
       write_genres
       write_authors
-      # write_labels
+      write_labels
     when 10
       goodbye
       exit

--- a/models/book.rb
+++ b/models/book.rb
@@ -4,7 +4,7 @@ require_relative 'genre'
 require_relative 'label'
 
 class Book < Item
-  attr_accessor :publisher, :cover_state
+  attr_accessor :publisher, :cover_state, :id
 
   def initialize(publisher, cover_state, *args)
     super(*args)
@@ -29,19 +29,19 @@ class Book < Item
 
   def self.add_books(books, genre, authors, labels)
     print 'Enter name of the book: '
-    label_title = gets.chomp
+    label_title = gets.chomp.capitalize
     print 'Book\'s creator first name: '
-    author_first_name = gets.chomp
+    author_first_name = gets.chomp.capitalize
     print 'Book\'s creator last name: '
-    author_last_name = gets.chomp
+    author_last_name = gets.chomp.capitalize
     print 'Enter the book\'s genre: '
-    genre_name = gets.chomp
+    genre_name = gets.chomp.capitalize
     print 'Enter the book\'s publisher: '
-    publisher_name = gets.chomp
+    publisher_name = gets.chomp.capitalize
     print 'Enter the book\'s cover state: '
-    cover_state = gets.chomp
+    cover_state = gets.chomp.capitalize
     print 'Enter the book\'s color: '
-    label_color = gets.chomp
+    label_color = gets.chomp.capitalize
 
     # item inputs
     print "\nWhat's the publish date? [year] "

--- a/models/game.rb
+++ b/models/game.rb
@@ -19,7 +19,7 @@ class Game < Item
       puts 'List of all games: '
       games.each do |game|
         if game.instance_of? Game
-          puts "#{index}) (ID:#{game.id}) The game: game.label , Author: #{game.author.first_name} #{game.author.last_name}, Genre: #{game.genre.name}, Publish Date: #{game.publish_date}"
+          puts "#{index}) (ID:#{game.id}) The game: #{game.label.title}, Author: #{game.author.first_name} #{game.author.last_name}, Genre: #{game.genre.name}, Publish Date: #{game.publish_date}"
           index += 1
         end
       end
@@ -28,13 +28,13 @@ class Game < Item
 
   def self.add_games(games, genre, authors, labels)
     print 'Enter name of the game: '
-    label_title = gets.chomp
+    label_title = gets.chomp.capitalize
     print 'Games\'s creator first name: '
-    author_first_name = gets.chomp
+    author_first_name = gets.chomp.capitalize
     print 'Game\'s creator last name: '
-    author_last_name = gets.chomp
+    author_last_name = gets.chomp.capitalize
     print 'Enter the game\'s genre: '
-    genre_name = gets.chomp
+    genre_name = gets.chomp.capitalize
 
     # item inputs
     print "\nWhat's the publish date? [year] "

--- a/models/music_album.rb
+++ b/models/music_album.rb
@@ -15,8 +15,8 @@ class MusicAlbum < Item
       puts 'No Music Albums found'
     else
       puts 'List of All Music Albums: '
-      music_albums.each_with_index do |music_album, index|
-        puts "#{index}) (ID:#{music_album.id}) Author: #{music_album.author.first_name} #{music_album.author.last_name}, Genre: #{music_album.genre.name}, Publish Date: #{music_album.publish_date}"
+      music_albums.each_with_index do |album, index|
+        puts "#{index}) (ID:#{album.id}) Title: #{album.label.title}, Author: #{album.author.first_name} #{album.author.last_name}, Genre: #{album.genre.name}, Publish Date: #{album.publish_date}"
       end
       puts
     end
@@ -24,7 +24,7 @@ class MusicAlbum < Item
 
   def self.add_music_album(music_albums, genre, authors, labels)
     print 'Enter name of the music album: '
-    label_title = gets.chomp
+    label_title = gets.chomp.capitalize
     print 'First Name of the author: '
     first_name = gets.chomp.capitalize
     print 'Last Name of the author: '

--- a/preserveData/load_data.rb
+++ b/preserveData/load_data.rb
@@ -2,6 +2,8 @@ require 'json'
 require './models/genre'
 require './models/music_album'
 require './models/author'
+require './models/book'
+require './models/label'
 
 module LoadData
   def load_genres
@@ -30,9 +32,11 @@ module LoadData
           new_music_album.on_spotify = music_album['on_spotify']
           new_author = authors.find { |find_author| find_author.first_name == music_album['first_name'] && find_author.last_name == music_album['last_name'] }
           new_genre = genre.find { |find_genre| find_genre.name == music_album['genre'] }
+          new_label = labels.find { |find_label| find_label.title == music_album['title'] && find_label.color == music_album['label_color'] }
 
           new_genre.add_item(new_music_album)
           new_author.add_item(new_music_album)
+          new_label.add_item(new_music_album)
 
           music_album_arr << new_music_album
         end
@@ -55,21 +59,60 @@ module LoadData
     authors_arr
   end
 
+  def load_labels
+    labels_arr = []
+    if File.exist?('./storage_data/labels.json')
+      labels_data = File.read('./storage_data/labels.json')
+      if labels_data != ''
+        JSON.parse(labels_data).map do |label|
+          new_label = Label.new(label['label_title'], label['label_color'], label['id'])
+          labels_arr << new_label
+        end
+      end
+    end
+    labels_arr
+  end
+
   def load_games
     games_arr = []
     if File.exist?('./storage_data/games.json')
       games_data = File.read('./storage_data/games.json')
       if games_data != ''
         JSON.parse(games_data).map do |game|
-          new_game = Game.new(game['multiplayer'], game['last_played_at'], game['id'], game['publish_date'])
+          new_game = Game.new(game['multiplayer'], game['last_played_at'], game['publish_date'], game['id'])
           new_author = authors.find { |find_author| find_author.first_name == game['first_name'] && find_author.last_name == game['last_name'] }
           new_genre = genre.find { |find_genre| find_genre.name == game['genre'] }
+          new_label = labels.find { |find_label| find_label.title == game['title'] && find_label.color == game['label_color'] }
           new_genre.add_item(new_game)
           new_author.add_item(new_game)
+          new_label.add_item(new_game)
           games_arr << new_game
         end
       end
     end
     games_arr
+  end
+
+  def load_books
+    books_arr = []
+    if File.exist?('./storage_data/books.json')
+      books_data = File.read('./storage_data/books.json')
+      if books_data != ''
+        JSON.parse(books_data).map do |book|
+          new_book = Book.new(book['publisher'], book['cover_state'], book['publish_date'])
+          new_book.id = book['id']
+          new_author = authors.find { |find_author| find_author.first_name == book['first_name'] && find_author.last_name == book['last_name'] }
+          new_label = labels.find { |find_label| find_label.title == book['title'] && find_label.color == book['label_color'] }
+          new_genre = genre.find { |find_genre| find_genre.name == book['genre'] }
+
+          new_genre.add_item(new_book)
+          new_author.add_item(new_book)
+          new_label.add_item(new_book)
+
+          books_arr << new_book
+        end
+      end
+    end
+    books_arr
   end
 end

--- a/preserveData/write_data.rb
+++ b/preserveData/write_data.rb
@@ -18,6 +18,8 @@ module WriteData
       new_music_album = {
         publish_date: music_album.publish_date,
         id: music_album.id,
+        title: music_album.label.title,
+        label_color: music_album.label.color,
         on_spotify: music_album.on_spotify,
         first_name: music_album.author.first_name,
         last_name: music_album.author.last_name,
@@ -45,6 +47,8 @@ module WriteData
       new_game = {
         publish_date: game.publish_date,
         id: game.id,
+        title: game.label.title,
+        label_color: game.label.color,
         multiplayer: game.multiplayer,
         last_played_at: game.last_played_at,
         first_name: game.author.first_name,

--- a/preserveData/write_data.rb
+++ b/preserveData/write_data.rb
@@ -57,4 +57,34 @@ module WriteData
     FileUtils.touch('./storage_data/games.json')
     File.write('./storage_data/games.json', JSON.pretty_generate(json_games))
   end
+
+  def write_books
+    json_books = []
+    books.each do |book|
+      new_book = {
+        publish_date: book.publish_date,
+        id: book.id,
+        title: book.label.title,
+        label_color: book.label.color,
+        publisher: book.publisher,
+        cover_state: book.cover_state,
+        first_name: book.author.first_name,
+        last_name: book.author.last_name,
+        genre: book.genre.name
+      }
+      json_books << new_book
+    end
+
+    FileUtils.touch('./storage_data/books.json')
+    File.write('./storage_data/books.json', JSON.pretty_generate(json_books))
+  end
+
+  def write_labels
+    json_labels = []
+    labels.each do |label|
+      json_labels << { label_title: label.title, label_color: label.color, id: label.id }
+    end
+    FileUtils.touch('./storage_data/labels.json')
+    File.write('./storage_data/labels.json', JSON.pretty_generate(json_labels))
+  end
 end

--- a/spec/book_spec.rb
+++ b/spec/book_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../book'
+require_relative '../models/book'
 require_relative '../item'
 
 describe Book do

--- a/spec/label_spec.rb
+++ b/spec/label_spec.rb
@@ -1,4 +1,3 @@
-require 'securerandom'
 require_relative '../models/label'
 
 describe Label do

--- a/storage_data/author.json
+++ b/storage_data/author.json
@@ -1,22 +1,17 @@
 [
   {
-    "first_name": "Asd",
-    "last_name": "Asd",
-    "id": 575
-  },
-  {
-    "first_name": "asd",
-    "last_name": "qwe",
-    "id": 369
-  },
-  {
     "first_name": "Luis",
     "last_name": "Valera",
-    "id": 716
+    "id": 438
   },
   {
-    "first_name": "Redman",
-    "last_name": "Dsd",
-    "id": 549
+    "first_name": "Sergio",
+    "last_name": "Luis",
+    "id": 489
+  },
+  {
+    "first_name": "Sergio",
+    "last_name": "Peralta",
+    "id": 946
   }
 ]

--- a/storage_data/author.json
+++ b/storage_data/author.json
@@ -8,5 +8,15 @@
     "first_name": "asd",
     "last_name": "qwe",
     "id": 369
+  },
+  {
+    "first_name": "Luis",
+    "last_name": "Valera",
+    "id": 716
+  },
+  {
+    "first_name": "Redman",
+    "last_name": "Dsd",
+    "id": 549
   }
 ]

--- a/storage_data/books.json
+++ b/storage_data/books.json
@@ -1,11 +1,11 @@
 [
   {
-    "publish_date": 2023,
-    "id": 880,
-    "title": "Moby Dick",
+    "publish_date": 1993,
+    "id": 71,
+    "title": "Romeo and Julieta",
     "label_color": "red",
-    "publisher": "",
-    "cover_state": "good",
+    "publisher": "My house",
+    "cover_state": "bad",
     "first_name": "Luis",
     "last_name": "Valera",
     "genre": "Adventure"

--- a/storage_data/books.json
+++ b/storage_data/books.json
@@ -1,0 +1,13 @@
+[
+  {
+    "publish_date": 2023,
+    "id": 880,
+    "title": "Moby Dick",
+    "label_color": "red",
+    "publisher": "",
+    "cover_state": "good",
+    "first_name": "Luis",
+    "last_name": "Valera",
+    "genre": "Adventure"
+  }
+]

--- a/storage_data/games.json
+++ b/storage_data/games.json
@@ -1,11 +1,13 @@
 [
   {
-    "publish_date": 1990,
-    "id": 875,
-    "multiplayer": true,
-    "last_played_at": 2000,
-    "first_name": "asd",
-    "last_name": "qwe",
-    "genre": "zxc"
+    "publish_date": 1993,
+    "id": 204,
+    "title": "Crash Bandicoot",
+    "label_color": "orange",
+    "multiplayer": false,
+    "last_played_at": 2001,
+    "first_name": "Sergio",
+    "last_name": "Peralta",
+    "genre": "Adventure"
   }
 ]

--- a/storage_data/genre.json
+++ b/storage_data/genre.json
@@ -1,18 +1,10 @@
 [
   {
-    "name": "Zxc",
-    "id": 874
-  },
-  {
-    "name": "zxc",
-    "id": 997
-  },
-  {
     "name": "Adventure",
-    "id": 333
+    "id": 284
   },
   {
     "name": "Rock",
-    "id": 56
+    "id": 134
   }
 ]

--- a/storage_data/genre.json
+++ b/storage_data/genre.json
@@ -6,5 +6,13 @@
   {
     "name": "zxc",
     "id": 997
+  },
+  {
+    "name": "Adventure",
+    "id": 333
+  },
+  {
+    "name": "Rock",
+    "id": 56
   }
 ]

--- a/storage_data/labels.json
+++ b/storage_data/labels.json
@@ -1,7 +1,17 @@
 [
   {
-    "label_title": "LEWDAD",
+    "label_title": "Romeo and Julieta",
     "label_color": "red",
-    "id": 545
+    "id": 924
+  },
+  {
+    "label_title": "The machine",
+    "label_color": "black",
+    "id": 343
+  },
+  {
+    "label_title": "Crash Bandicoot",
+    "label_color": "orange",
+    "id": 254
   }
 ]

--- a/storage_data/labels.json
+++ b/storage_data/labels.json
@@ -1,0 +1,7 @@
+[
+  {
+    "label_title": "LEWDAD",
+    "label_color": "red",
+    "id": 545
+  }
+]

--- a/storage_data/music_albums.json
+++ b/storage_data/music_albums.json
@@ -1,26 +1,12 @@
 [
   {
-    "publish_date": "2020/20/20",
-    "id": 408,
+    "publish_date": "2009/04/04",
+    "id": 721,
+    "title": "The machine",
+    "label_color": "black",
     "on_spotify": false,
-    "first_name": "Asd",
-    "last_name": "Asd",
-    "genre": "Zxc"
-  },
-  {
-    "publish_date": "2023/03/03",
-    "id": 218,
-    "on_spotify": false,
-    "first_name": "Luis",
-    "last_name": "Valera",
-    "genre": "Rock"
-  },
-  {
-    "publish_date": "2022/02/02",
-    "id": 558,
-    "on_spotify": false,
-    "first_name": "Redman",
-    "last_name": "Dsd",
+    "first_name": "Sergio",
+    "last_name": "Luis",
     "genre": "Rock"
   }
 ]

--- a/storage_data/music_albums.json
+++ b/storage_data/music_albums.json
@@ -6,5 +6,21 @@
     "first_name": "Asd",
     "last_name": "Asd",
     "genre": "Zxc"
+  },
+  {
+    "publish_date": "2023/03/03",
+    "id": 218,
+    "on_spotify": false,
+    "first_name": "Luis",
+    "last_name": "Valera",
+    "genre": "Rock"
+  },
+  {
+    "publish_date": "2022/02/02",
+    "id": 558,
+    "on_spotify": false,
+    "first_name": "Redman",
+    "last_name": "Dsd",
+    "genre": "Rock"
   }
 ]


### PR DESCRIPTION
In this branch, I was working on preserving the data of labels and books and I achieve the following tasks:

- Create `write_books` and `write_labels` to add data to json files.
- Create `load_books` and `load_labels` to get the data from json files.
- Add labels option to the other load methods.
- Fix some minor problems.
- No linters errors